### PR TITLE
Add redirect for web.community/hour

### DIFF
--- a/hour.html
+++ b/hour.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <title>web community hour ✨</title>
+    <meta http-equiv="refresh" content="0; URL=https://docs.google.com/presentation/d/1PE_taRS8sFJi5WgNEUiCglS26sniASpGFBpshB9yjGk/edit" />
+  </head>
+</html>


### PR DESCRIPTION
In lieu of go links, we can create html meta redirects - this will let us type `web.community/hour` in an address bar, or link to https://web.community/hour, and redirect to the appropriate slides. When the slide url changes, we'll need to update this file.